### PR TITLE
Add keyboard navigation support.

### DIFF
--- a/components/CartDrawer/CartDrawer.js
+++ b/components/CartDrawer/CartDrawer.js
@@ -59,12 +59,7 @@ class CartDrawer extends Component {
             Your Cart
           </Typography>
         ) : null}
-        <div
-          className={classes.list}
-          tabIndex={0}
-          role="button"
-          onKeyDown={toggleDrawer('drawerCart', false)}
-        >
+        <div className={classes.list} role="button">
           {sideCart}
           {uniqueCartItems > 0 ? (
             <div style={{ width: 280 }}>

--- a/components/CartDrawer/CartDrawerContent.js
+++ b/components/CartDrawer/CartDrawerContent.js
@@ -31,6 +31,12 @@ const CartDrawerContent = props => {
     props.closeDrawer();
   };
 
+  const keyDownHandler = ({ key }) => {
+    if (key === 'Enter') {
+      buttonClickHandler();
+    }
+  };
+
   const { classes } = props;
 
   let content = (
@@ -44,6 +50,7 @@ const CartDrawerContent = props => {
         variant="contained"
         color="secondary"
         onClick={() => buttonClickHandler()}
+        onKeyDown={e => keyDownHandler(e)}
       >
         SHOP
       </Button>

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -85,33 +85,25 @@ class NavBar extends React.Component {
     };
   }
 
-  handleChange = (event, value) => {
-    this.setState({ value });
-    if (value === '/') {
-      Router.push('/');
-    }
-    // if (value == '/works') {
-    //   Router.push('/works');
-    // }
-    if (value === '/about') {
-      Router.push('/about');
-    }
-    if (value === '/contact') {
-      Router.push('/contact');
+  handleNavBarChange = (event, value) => {
+    // on works click we just opening menu, not redirecting
+    if (value !== '/works') {
+      this.setState({ value });
+      Router.push(value);
     }
   };
 
-  handleClick = event => {
+  openMenu = event => {
     this.setState({ anchorEl: event.currentTarget });
   };
 
-  handleClose = (e, href, as) => {
-    // just actually closing panel
-    if (href !== 'backdropClick') {
-      Router.push(href, as);
-    }
+  handleMenuItemClick = (href, as) => {
+    this.closeMenu();
+    Router.push(href, as);
+  };
 
-    this.setState({ anchorEl: null, value: false });
+  closeMenu = () => {
+    this.setState({ anchorEl: null });
   };
 
   render() {
@@ -120,7 +112,7 @@ class NavBar extends React.Component {
     const navigation = (
       <Tabs
         value={value}
-        onChange={this.handleChange}
+        onChange={this.handleNavBarChange}
         indicatorColor="secondary"
         textColor="secondary"
         centered
@@ -142,7 +134,7 @@ class NavBar extends React.Component {
           value="/works"
           aria-owns={anchorEl ? pathname : null}
           aria-haspopup="true"
-          onClick={this.handleClick}
+          onClick={this.openMenu}
         />
         <Tab label="About" value="/about" to="/about" />
         <Tab label="Contact" value="/contact" to="/contact" />
@@ -184,17 +176,16 @@ class NavBar extends React.Component {
                   id="simple-menu"
                   anchorEl={anchorEl}
                   open={Boolean(anchorEl)}
-                  onClose={e => this.handleClose(e, 'backdropClick')}
+                  onClose={this.closeMenu}
                 >
-                  <MenuItem onClick={e => this.handleClose(e, '/works')}>
+                  <MenuItem onClick={() => this.handleMenuItemClick('/works')}>
                     SHOW ALL
                   </MenuItem>
                   {collections.map(collection => (
                     <MenuItem
                       key={collection}
-                      onClick={e =>
-                        this.handleClose(
-                          e,
+                      onClick={() =>
+                        this.handleMenuItemClick(
                           `/works?collection=${collection}`,
                           `/works/${collection}`
                         )

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -97,7 +97,7 @@ class NavBar extends React.Component {
     this.setState({ anchorEl: event.currentTarget });
   };
 
-  handleMenuItemClick = (href, as) => {
+  handleMenuItemClick = (href, as) => () => {
     this.closeMenu();
     Router.push(href, as);
   };
@@ -178,18 +178,16 @@ class NavBar extends React.Component {
                   open={Boolean(anchorEl)}
                   onClose={this.closeMenu}
                 >
-                  <MenuItem onClick={() => this.handleMenuItemClick('/works')}>
+                  <MenuItem onClick={this.handleMenuItemClick('/works')}>
                     SHOW ALL
                   </MenuItem>
                   {collections.map(collection => (
                     <MenuItem
                       key={collection}
-                      onClick={() =>
-                        this.handleMenuItemClick(
-                          `/works?collection=${collection}`,
-                          `/works/${collection}`
-                        )
-                      }
+                      onClick={this.handleMenuItemClick(
+                        `/works?collection=${collection}`,
+                        `/works/${collection}`
+                      )}
                     >
                       {collection.toUpperCase()}
                     </MenuItem>

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -184,7 +184,7 @@ class NavBar extends React.Component {
                   id="simple-menu"
                   anchorEl={anchorEl}
                   open={Boolean(anchorEl)}
-                  onClose={this.handleClose}
+                  onClose={e => this.handleClose(e, 'backdropClick')}
                 >
                   <MenuItem onClick={e => this.handleClose(e, '/works')}>
                     SHOW ALL

--- a/components/NavDrawer/NavDrawer.js
+++ b/components/NavDrawer/NavDrawer.js
@@ -34,12 +34,7 @@ class NavDrawer extends Component {
           onClose={toggleDrawer('drawerNav', false)}
           onOpen={toggleDrawer('drawerNav', true)}
         >
-          <div
-            className={classes.list}
-            tabIndex={0}
-            role="button"
-            onKeyDown={toggleDrawer('drawerNav', false)}
-          >
+          <div className={classes.list} tabIndex={-1} role="button">
             {sideNavList}
           </div>
         </Drawer>

--- a/components/NavDrawer/NavDrawerContent.js
+++ b/components/NavDrawer/NavDrawerContent.js
@@ -24,12 +24,25 @@ class NavDrawerContent extends React.Component {
     closingDrawer();
   };
 
+  handleKeyDown = ({ key }, collection, href) => {
+    if (key === 'Enter' || key === ' ') {
+      if (collection) {
+        this.handleClick(
+          `/works?collection=${collection}`,
+          `/works/${collection}`
+        );
+      } else {
+        this.handleClick(href);
+      }
+    }
+  };
+
   render() {
     const { open } = this.state;
     const { collections } = this.props;
     return (
       <List>
-        <ListItem button>
+        <ListItem button onKeyDown={e => this.handleKeyDown(e, null, '/')}>
           <Link href="/">
             <ListItemText primary="Home" />
           </Link>
@@ -40,8 +53,26 @@ class NavDrawerContent extends React.Component {
         </ListItem>
         <Collapse in={open} timeout="auto" unmountOnExit>
           <List component="div">
+            <ListItem
+              button
+              key="works"
+              onKeyDown={e => this.handleKeyDown(e, null, '/works')}
+            >
+              <ListItemText
+                inset
+                primary="SHOW ALL"
+                style={{ paddingLeft: '16px' }}
+                onClick={() =>
+                  this.handleClick(`/works?collection=works`, `/works/works`)
+                }
+              />
+            </ListItem>
             {collections.map(collection => (
-              <ListItem button key={collection}>
+              <ListItem
+                button
+                key={collection}
+                onKeyDown={e => this.handleKeyDown(e, collection)}
+              >
                 <ListItemText
                   inset
                   primary={collection.toUpperCase()}
@@ -57,12 +88,20 @@ class NavDrawerContent extends React.Component {
             ))}
           </List>
         </Collapse>
-        <ListItem button to="/about">
+        <ListItem
+          button
+          to="/about"
+          onKeyDown={e => this.handleKeyDown(e, null, '/about')}
+        >
           <Link href="/about">
             <ListItemText primary="About" />
           </Link>
         </ListItem>
-        <ListItem button to="/contact">
+        <ListItem
+          button
+          to="/contact"
+          onKeyDown={e => this.handleKeyDown(e, null, '/contact')}
+        >
           <Link href="/contact">
             <ListItemText primary="Contact" />
           </Link>


### PR DESCRIPTION
This would fix #24. One issue, though. Navigation drawer on small screen uses material-ui <List> component so user can navigate with `Tab` key. On the other hand, in navigation bar Works' dropdown uses \<Menu> component and it can be navigated only with arrow keys. A little inconsistency but maybe we can live with that?
