### PR TITLE
Remove unnecessary count variable.

### DIFF
--- a/containers/Stripe/Form.js
+++ b/containers/Stripe/Form.js
@@ -171,12 +171,10 @@ class StripeForm extends Component {
             };
           } else {
             console.log('is cart pirko');
-            const count = cart.length;
             const selectedItems = cart;
             const totalItems = cartHelper.totalItems(cart);
             const totalPrice = cartHelper.totalPrice(cart);
             purchaseDetails = {
-              count,
               selectedItems,
               totalItems,
               totalPrice,


### PR DESCRIPTION
This is used just for storing in orders collection to track count of items, but that can easily be counted as `selectedItems.length` and unique `totalItems` is more useful measurement either way. This solves #36 

```json
{
    <...>
    "purchaseDetails": {
        "count": 2,
        "selectedItems": [{
            "name": "test",
            "price": 3,
            "images": [],
            "_id": "5ca3a41c45cdff2411af5f6c",
            "available": true,
            "quantity": 2
        }, {
            "name": "n'23",
            "price": 185,
            "images": [],
            "_id": "5ca241ab9f1f821ea19277ca",
            "available": true,
            "quantity": 1
        }],
        "totalItems": 3,
        "totalPrice": 191,
        "boughtFrom": "cart",
        "shippingCost": 5
    },
    <...>
}
```