### PR TITLE
Refactor image gallery

### DIFF
--- a/components/ItemCard/customRenderItem.js
+++ b/components/ItemCard/customRenderItem.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { onImageError } from '../../util/helpers';
 
 const ImageContainer = styled.div`
   width: 100%;
@@ -14,49 +15,39 @@ const ImageContainer = styled.div`
   }
 `;
 
-const renderItem = item => {
-  const defaultImage = '/static/images/logo.png';
-
-  const onImageError = event => {
-    if (event.target.src.indexOf(defaultImage) === -1) {
-      event.target.src = defaultImage;
-    }
-  };
-
-  return (
-    <div className="image-gallery-image">
-      {item.imageSet ? (
-        <picture onError={e => onImageError(e)}>
-          {item.imageSet.map((source, index) => (
-            <source
-              key={index}
-              media={source.media}
-              srcSet={source.srcSet}
-              type={source.type}
-            />
-          ))}
-          <ImageContainer>
-            <img alt={item.originalAlt} src={item.original} />
-          </ImageContainer>
-        </picture>
-      ) : (
-        <ImageContainer>
-          <img
-            src={item.original}
-            alt={item.originalAlt}
-            srcSet={item.srcSet}
-            sizes={item.sizes}
-            title={item.originalTitle}
-            onError={e => onImageError(e)}
+const renderItem = item => (
+  <div className="image-gallery-image">
+    {item.imageSet ? (
+      <picture onError={onImageError}>
+        {item.imageSet.map((source, index) => (
+          <source
+            key={index}
+            media={source.media}
+            srcSet={source.srcSet}
+            type={source.type}
           />
+        ))}
+        <ImageContainer>
+          <img alt={item.originalAlt} src={item.original} />
         </ImageContainer>
-      )}
+      </picture>
+    ) : (
+      <ImageContainer>
+        <img
+          src={item.original}
+          alt={item.originalAlt}
+          srcSet={item.srcSet}
+          sizes={item.sizes}
+          title={item.originalTitle}
+          onError={onImageError}
+        />
+      </ImageContainer>
+    )}
 
-      {item.description && (
-        <span className="image-gallery-description">{item.description}</span>
-      )}
-    </div>
-  );
-};
+    {item.description && (
+      <span className="image-gallery-description">{item.description}</span>
+    )}
+  </div>
+);
 
 export default renderItem;

--- a/components/ItemCard/customRenderThumb.js
+++ b/components/ItemCard/customRenderThumb.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { onImageError } from '../../util/helpers';
 
 const ThumbnailContainer = styled.div`
   width: 100%;
@@ -14,31 +15,20 @@ const ThumbnailContainer = styled.div`
   }
 `;
 
-const renderThumb = item => {
-  const defaultImage = '/static/images/logo.png';
-
-  const onThumbnailError = event => {
-    if (event.target.src.indexOf(defaultImage) === -1) {
-      event.target.src = defaultImage;
-    }
-  };
-  return (
-    <div className="image-gallery-thumbnail-inner">
-      <ThumbnailContainer>
-        <img
-          src={item.thumbnail}
-          alt={item.thumbnailAlt}
-          title={item.thumbnailTitle}
-          onError={e => onThumbnailError(e)}
-        />
-      </ThumbnailContainer>
-      {item.thumbnailLabel && (
-        <div className="image-gallery-thumbnail-label">
-          {item.thumbnailLabel}
-        </div>
-      )}
-    </div>
-  );
-};
+const renderThumb = item => (
+  <div className="image-gallery-thumbnail-inner">
+    <ThumbnailContainer>
+      <img
+        src={item.thumbnail}
+        alt={item.thumbnailAlt}
+        title={item.thumbnailTitle}
+        onError={onImageError}
+      />
+    </ThumbnailContainer>
+    {item.thumbnailLabel && (
+      <div className="image-gallery-thumbnail-label">{item.thumbnailLabel}</div>
+    )}
+  </div>
+);
 
 export default renderThumb;

--- a/pages/about.js
+++ b/pages/about.js
@@ -20,6 +20,7 @@ import {
   Data,
   ImageGalleryWrapper
 } from '../styles/About';
+import { onImageError } from '../util/helpers';
 
 const options = {
   accessToken: '1759380932.1677ed0.eb657c77753b4871aee13b962fe9b3b9',
@@ -50,12 +51,10 @@ class About extends React.Component {
   _renderItem = item => {
     const { width } = this.props;
 
-    const onImageError = imageError || this._handleImageError;
-
     return (
       <div className="image-gallery-image">
         {item.imageSet ? (
-          <picture onLoad={onImageLoad} onError={onImageError}>
+          <picture onError={onImageError}>
             {item.imageSet.map((source, index) => (
               <source
                 key={index}
@@ -73,7 +72,6 @@ class About extends React.Component {
             srcSet={item.srcSet}
             sizes={item.sizes}
             title={item.originalTitle}
-            onLoad={onImageLoad}
             onError={onImageError}
           />
         )}

--- a/pages/about.js
+++ b/pages/about.js
@@ -48,7 +48,7 @@ const styles = theme => ({
 
 class About extends React.Component {
   _renderItem = item => {
-    const { onImageError: imageError, onImageLoad, width } = this.props;
+    const { width } = this.props;
 
     const onImageError = imageError || this._handleImageError;
 
@@ -571,9 +571,7 @@ About.propTypes = {
   pathname: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   collections: PropTypes.arrayOf(PropTypes.string),
   width: PropTypes.string,
-  instagram: PropTypes.object,
-  onImageError: PropTypes.func,
-  onImageLoad: PropTypes.func
+  instagram: PropTypes.object
 };
 
 About.getInitialProps = async ({ pathname }) => {

--- a/util/helpers.js
+++ b/util/helpers.js
@@ -14,3 +14,12 @@ export const cartHelper = {
     return totalPrice;
   }
 };
+
+export const onImageError = event => {
+  const defaultImage = '/static/images/logo.png';
+
+  if (event.target.src.indexOf('/static/images/logo.png') === -1) {
+    event.target.src = defaultImage;
+    event.target.srcset = '';
+  }
+};


### PR DESCRIPTION
This fixes #39, plus in addition to removing unnecessary props, I've handled onImageError in one place in helpers.js not to use same function in three different places. Also added `event.target.srcset = ''` to wipe out srcset path's as if its not cleared fallback image isn't shown for images with srcset. 