### PR TITLE
fix: git ignore static/uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.next
 node_modules/
 .env
+static/uploads
+


### PR DESCRIPTION
added static/uploads to .gitignore.
I think we should put the images elsewhere, but we can address that later.