### PR TITLE
Filter items by category

### DIFF
--- a/components/Gallery/Filter.js
+++ b/components/Gallery/Filter.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Select, InputLabel, FormControl } from '@material-ui/core';
+import { withStyles } from '@material-ui/core/styles';
+
+const styles = () => ({
+  root: {
+    marginLeft: 'auto'
+  }
+});
+
+const Filter = ({ classes, data, option, handleChange }) => (
+  <FormControl className={classes.root}>
+    <InputLabel htmlFor="filter-gallery" />
+    <Select
+      native
+      value={option}
+      onChange={handleChange}
+      inputProps={{
+        id: 'filter-gallery'
+      }}
+    >
+      <option value="">Show all</option>
+      {data
+        .reduce((acc, item) => {
+          if (!acc.includes(item.category)) acc.push(item.category);
+          return acc;
+        }, [])
+        .map(category => (
+          <option key={category} value={category}>
+            {category.charAt(0).toUpperCase() + category.substring(1)}
+          </option>
+        ))}
+    </Select>
+  </FormControl>
+);
+
+Filter.propTypes = {
+  classes: PropTypes.object.isRequired,
+  data: PropTypes.arrayOf(PropTypes.object),
+  option: PropTypes.string,
+  handleChange: PropTypes.func
+};
+
+export default withStyles(styles)(Filter);

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,124 +1,45 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Link from 'next/link';
-import styled from 'styled-components';
-import { connect } from 'react-redux';
-import { Button } from '@material-ui/core';
 
 import Layout from '../components/Layout';
 import Gallery from '../components/Gallery/Gallery';
 
-import { increaseLoadedItems } from '../store/actions';
-
-const ButtonContainer = styled.div`
-  text-align: center;
-  margin-bottom: 20px;
-  @media (min-width: 960px) {
-    padding-bottom: 40px;
-    padding-top: 20px;
-  }
-`;
-
-class Index extends React.Component {
-  constructor(props) {
-    super(props);
-    const { data } = props;
-    this.state = {
-      data,
-      itemsLoaded: props.reduxLoadedItems,
-      dataForGallery: data.slice(0, props.reduxLoadedItems)
-    };
-  }
-
-  componentDidUpdate(prevProps) {
-    const { reduxLoadedItems } = this.props;
-
-    /* eslint-disable react/no-did-update-set-state */
-    if (reduxLoadedItems !== prevProps.reduxLoadedItems) {
-      this.setState(prevState => ({
-        dataForGallery: prevState.data.slice(0, reduxLoadedItems),
-        itemsLoaded: reduxLoadedItems
-      }));
-    }
-    /* eslint-enable react/no-did-update-set-state */
-  }
-
-  render() {
-    const {
-      pathname,
-      collections,
-      from,
-      increaseLoadedItems: increaseLoadedItemsRedux
-    } = this.props;
-    const { data, dataForGallery, itemsLoaded } = this.state;
-
-    return (
-      <Layout pathname={pathname} collections={collections}>
-        <div>alohha</div>
-        <Link href="/works">
-          <a>Works</a>
-        </Link>
-        <br />
-        <Link href="/checkout">
-          <a>checkout</a>
-        </Link>
-        <br />
-        <Link href="/admin">
-          <a>admin</a>
-        </Link>
-        <br />
-        <Link href="/about">
-          <a>About</a>
-        </Link>
-        <br />
-        <Link href="/">
-          <a>Home</a>
-        </Link>
-        <div>Path: {pathname}</div>
-        <div>From: {from}</div>
-        {/* <div>Data: {JSON.stringify(this.state.data)}</div> */}
-        {data.length > 0 ? (
-          <Gallery data={dataForGallery} showCollection="all" />
-        ) : (
-          <p>Gallery empty</p>
-        )}
-        {data.length > itemsLoaded ? (
-          <ButtonContainer>
-            <Button
-              size="medium"
-              variant="contained"
-              color="secondary"
-              onClick={() => increaseLoadedItemsRedux()}
-            >
-              Load More
-            </Button>
-          </ButtonContainer>
-        ) : null}
-      </Layout>
-    );
-  }
-}
+const Index = ({ data, pathname, collections, from }) => (
+  <Layout pathname={pathname} collections={collections}>
+    <div>alohha</div>
+    <Link href="/works">
+      <a>Works</a>
+    </Link>
+    <br />
+    <Link href="/checkout">
+      <a>checkout</a>
+    </Link>
+    <br />
+    <Link href="/admin">
+      <a>admin</a>
+    </Link>
+    <br />
+    <Link href="/about">
+      <a>About</a>
+    </Link>
+    <br />
+    <Link href="/">
+      <a>Home</a>
+    </Link>
+    <div>Path: {pathname}</div>
+    <div>From: {from}</div>
+    <Gallery data={data} showCollection="all" collectionsNames={collections} />
+  </Layout>
+);
 
 Index.propTypes = {
   pathname: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   collections: PropTypes.arrayOf(PropTypes.string),
   data: PropTypes.array,
-  reduxLoadedItems: PropTypes.number,
-  from: PropTypes.string,
-  increaseLoadedItems: PropTypes.func
+  from: PropTypes.string
 };
 
 Index.getInitialProps = async ({ pathname, user }) => ({ pathname, user });
 
-const mapStateToProps = state => ({
-  reduxLoadedItems: state.loadMore
-});
-
-const mapDispatchToProps = dispatch => ({
-  increaseLoadedItems: () => dispatch(increaseLoadedItems())
-});
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Index);
+export default Index;

--- a/pages/works.js
+++ b/pages/works.js
@@ -1,154 +1,46 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Link from 'next/link';
-import styled from 'styled-components';
-import { connect } from 'react-redux';
-import { Button } from '@material-ui/core';
 
 import Layout from '../components/Layout';
 import Gallery from '../components/Gallery/Gallery';
-import { increaseLoadedItems } from '../store/actions';
-import { ITEMS_PER_PAGE } from '../config';
 
-const ButtonContainer = styled.div`
-  text-align: center;
-  margin-bottom: 20px;
-  @media (min-width: 960px) {
-    padding-bottom: 40px;
-    padding-top: 20px;
-  }
-`;
+const Works = ({ data, router, pathname, from, collections }) => {
+  let { collection } = router.query;
 
-class Works extends React.Component {
-  constructor(props) {
-    super(props);
-    const { data, collections: collectionsNames, reduxLoadedItems } = props;
-    const collections = {
-      all: { data, itemsLoaded: reduxLoadedItems.all }
-    };
-
-    const dataForSelectedCollection = (allItemsData, collection) =>
-      allItemsData.filter(x => x.group === collection);
-
-    collectionsNames.forEach(collection => {
-      collections[collection] = {
-        data: dataForSelectedCollection(data, collection),
-        itemsLoaded: reduxLoadedItems[collection] || ITEMS_PER_PAGE
-      };
-    });
-
-    this.state = {
-      data,
-      collections: { ...collections }
-    };
+  if (!collections.includes(collection)) {
+    collection = 'all';
   }
 
-  loadMore(collection) {
-    const { increaseLoadedItems: increaseLoadedItemsRedux } = this.props;
+  return (
+    <Layout pathname={pathname} collections={collections}>
+      <div>
+        <p>This is Works page.</p>
+        <p>path: {pathname}</p>
+        <p>from: {from}</p>
+        <Link href="/piece">
+          <a>Dedicated item page</a>
+        </Link>
 
-    increaseLoadedItemsRedux(collection);
-
-    this.setState(prevState => ({
-      collections: {
-        ...prevState.collections,
-        [collection]: {
-          data: prevState.collections[collection].data,
-          itemsLoaded:
-            prevState.collections[collection].itemsLoaded + ITEMS_PER_PAGE
-        }
-      }
-    }));
-  }
-
-  render() {
-    const {
-      router,
-      pathname,
-      from,
-      collections: collectionsNames
-    } = this.props;
-    const { collections } = this.state;
-
-    let { collection: collectionToDisplay } = router.query;
-
-    if (!collectionsNames.includes(collectionToDisplay)) {
-      collectionToDisplay = 'all';
-    }
-
-    let gallery = <p>Gallery empty</p>;
-    let loadMoreButton = null;
-
-    if (
-      collections[collectionToDisplay] &&
-      collections[collectionToDisplay].data.length > 0
-    ) {
-      gallery = (
         <Gallery
-          data={collections[collectionToDisplay].data.slice(
-            0,
-            collections[collectionToDisplay].itemsLoaded
-          )}
-          showCollection={collectionToDisplay}
+          data={data}
+          showCollection={collection}
+          collectionsNames={collections}
+          showFilter
         />
-      );
-
-      if (
-        collections[collectionToDisplay].data.length >
-        collections[collectionToDisplay].itemsLoaded
-      ) {
-        loadMoreButton = (
-          <ButtonContainer>
-            <Button
-              size="medium"
-              variant="contained"
-              color="secondary"
-              onClick={() => this.loadMore(collectionToDisplay)}
-            >
-              Load More
-            </Button>
-          </ButtonContainer>
-        );
-      }
-    }
-
-    return (
-      <Layout pathname={pathname} collections={collectionsNames}>
-        <div>
-          <p>This is Works page.</p>
-          <p>path: {pathname}</p>
-          <p>from: {from}</p>
-          <Link href="/piece">
-            <a>Dedicated item page</a>
-          </Link>
-          {gallery}
-          {loadMoreButton}
-        </div>
-      </Layout>
-    );
-  }
-}
+      </div>
+    </Layout>
+  );
+};
 
 Works.propTypes = {
   pathname: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   collections: PropTypes.arrayOf(PropTypes.string),
   data: PropTypes.array,
   router: PropTypes.object,
-  from: PropTypes.string,
-  increaseLoadedItems: PropTypes.func,
-  reduxLoadedItems: PropTypes.object
+  from: PropTypes.string
 };
 
 Works.getInitialProps = async ({ pathname }) => ({ pathname });
 
-const mapStateToProps = state => ({
-  reduxLoadedItems: state.loadMore
-});
-
-const mapDispatchToProps = dispatch => ({
-  increaseLoadedItems: collection => dispatch(increaseLoadedItems(collection))
-});
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Works);
+export default Works;

--- a/pages/works.js
+++ b/pages/works.js
@@ -8,6 +8,7 @@ import { Button } from '@material-ui/core';
 import Layout from '../components/Layout';
 import Gallery from '../components/Gallery/Gallery';
 import { increaseLoadedItems } from '../store/actions';
+import { ITEMS_PER_PAGE } from '../config';
 
 const ButtonContainer = styled.div`
   text-align: center;
@@ -23,7 +24,7 @@ class Works extends React.Component {
     super(props);
     const { data, collections: collectionsNames, reduxLoadedItems } = props;
     const collections = {
-      all: { data, itemsLoaded: reduxLoadedItems }
+      all: { data, itemsLoaded: reduxLoadedItems.all }
     };
 
     const dataForSelectedCollection = (allItemsData, collection) =>
@@ -32,7 +33,7 @@ class Works extends React.Component {
     collectionsNames.forEach(collection => {
       collections[collection] = {
         data: dataForSelectedCollection(data, collection),
-        itemsLoaded: reduxLoadedItems
+        itemsLoaded: reduxLoadedItems[collection] || ITEMS_PER_PAGE
       };
     });
 
@@ -43,12 +44,9 @@ class Works extends React.Component {
   }
 
   loadMore(collection) {
-    const {
-      reduxLoadedItems,
-      increaseLoadedItems: increaseLoadedItemsRedux
-    } = this.props;
+    const { increaseLoadedItems: increaseLoadedItemsRedux } = this.props;
 
-    increaseLoadedItemsRedux();
+    increaseLoadedItemsRedux(collection);
 
     this.setState(prevState => ({
       collections: {
@@ -56,15 +54,13 @@ class Works extends React.Component {
         [collection]: {
           data: prevState.collections[collection].data,
           itemsLoaded:
-            prevState.collections[collection].itemsLoaded + reduxLoadedItems
+            prevState.collections[collection].itemsLoaded + ITEMS_PER_PAGE
         }
       }
     }));
   }
 
   render() {
-    console.log(this.state);
-
     const {
       router,
       pathname,
@@ -149,7 +145,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  increaseLoadedItems: () => dispatch(increaseLoadedItems())
+  increaseLoadedItems: collection => dispatch(increaseLoadedItems(collection))
 });
 
 export default connect(

--- a/pages/works.js
+++ b/pages/works.js
@@ -135,7 +135,7 @@ Works.propTypes = {
   router: PropTypes.object,
   from: PropTypes.string,
   increaseLoadedItems: PropTypes.func,
-  reduxLoadedItems: PropTypes.number
+  reduxLoadedItems: PropTypes.object
 };
 
 Works.getInitialProps = async ({ pathname }) => ({ pathname });

--- a/store/actions/index.js
+++ b/store/actions/index.js
@@ -35,8 +35,9 @@ export const clearCart = () => ({ type: actionTypes.CLEAR_CART });
 
 export const clearBuyItNow = () => ({ type: actionTypes.CLEAR_BUY_IT_NOW });
 
-export const increaseLoadedItems = () => ({
-  type: actionTypes.INCREASE_LOADED_ITEMS
+export const increaseLoadedItems = collection => ({
+  type: actionTypes.INCREASE_LOADED_ITEMS,
+  collection
 });
 
 // gets token from the api and stores it in the redux store and in cookie

--- a/store/reducers/index.js
+++ b/store/reducers/index.js
@@ -22,7 +22,7 @@ export const initialState = {
   buyItNow: {},
   shippingCost: shippingPrice,
   authenticate: { token: null },
-  loadMore: ITEMS_PER_PAGE
+  loadMore: { all: ITEMS_PER_PAGE }
 };
 
 const cart = (state = initialState.cart, action) => {
@@ -91,7 +91,11 @@ const authenticate = (state = initialState.authenticate, action) => {
 
 const loadMore = (state = initialState.loadMore, action) => {
   if (INCREASE_LOADED_ITEMS === action.type) {
-    return state + 6;
+    return {
+      ...state,
+      [action.collection]:
+        (state[action.collection] || ITEMS_PER_PAGE) + ITEMS_PER_PAGE
+    };
   }
   return state;
 };


### PR DESCRIPTION
Was planning on making a _search_ by category or something else but I don't think is very needed so implemented a _filter_ by category instead. Chose not to show filter on index page for now. Will want to implement some hero image or something on landing page first to see how it looks.
Known limitation(if at all): if collection is big and filter for `Ring` is selected it will load and show all rings in the collection, not stopping at selected `ITEMS_PER_PAGE` value. Anyway, this constant will be ~40 and I doubt that any collection will ever be bigger than that.