### PR TITLE
Fix style jumping on load

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,8 @@
 {
   "presets": ["next/babel"],
   "plugins": [
-    ["babel-plugin-styled-components", {
-      "pure": true,
-      "preprocess": false
+    ["styled-components", {
+      "ssr": true
     }],
     ["import",
       {

--- a/components/NavBar/NavBar.js
+++ b/components/NavBar/NavBar.js
@@ -38,9 +38,6 @@ const styles = theme => ({
     marginLeft: 20,
     marginRight: 0
   },
-  tabIndicator: {
-    display: 'none'
-  },
   toggleNav: {
     [theme.breakpoints.up('md')]: {
       display: 'visible'

--- a/components/NavBar/NavBar.js
+++ b/components/NavBar/NavBar.js
@@ -16,12 +16,14 @@ import {
 import MenuIcon from '@material-ui/icons/Menu';
 import { ArrowDropDown, ArrowDropUp } from '@material-ui/icons';
 import { withStyles } from '@material-ui/core/styles';
+import Link from 'next/link';
 
 import NavDrawer from '../NavDrawer/NavDrawer';
 import CartDrawer from '../CartDrawer/CartDrawer';
 import { DrawerContext } from '../DrawerContext';
 import ShoppingBasket from './ShoppingBasket';
 import { Wrapper, WrapSpan, Span } from '../../styles/NavBar';
+import { AnchorLink } from '../../styles/Shared';
 
 const styles = theme => ({
   flex: {
@@ -159,14 +161,20 @@ class NavBar extends React.Component {
         <AppBar>
           <Toolbar>
             {smallMenu}
-            <Typography
-              variant="h6"
-              component="h1"
-              color="inherit"
-              className={classes.flex}
-            >
-              Dovile Jewellery
-            </Typography>
+            <div className={classes.flex}>
+              <Link href="/">
+                <AnchorLink>
+                  <Typography
+                    variant="h6"
+                    component="h1"
+                    color="inherit"
+                    className={classes.flex}
+                  >
+                    Dovile Jewellery
+                  </Typography>
+                </AnchorLink>
+              </Link>
+            </div>
             {navigation}
             <Menu
               id="simple-menu"

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -132,35 +132,36 @@ class MyApp extends App {
     return (
       <React.Fragment>
         <Container>
-          <Provider store={reduxStore}>
-            {/* Wrap every page in Jss and Theme providers */}
-            <JssProvider
-              registry={this.pageContext.sheetsRegistry}
-              generateClassName={this.pageContext.generateClassName}
-            >
-              {/* MuiThemeProvider makes the theme available down the React
+          <Head>
+            <title>
+              Jewellery artist Dovile Kondrasovaite | Dovile Jewellery
+            </title>
+            <meta
+              name="Description"
+              content="Contemporary amber jewellery with a delicate and modern touch by Dovile Kondrasovaite. Shop authentic handmade jewelry made by independent artist."
+            />
+          </Head>
+          {/* Wrap every page in Jss and Theme providers */}
+          <JssProvider
+            registry={this.pageContext.sheetsRegistry}
+            generateClassName={this.pageContext.generateClassName}
+          >
+            {/* MuiThemeProvider makes the theme available down the React
               tree thanks to React context. */}
-              <MuiThemeProvider
-                theme={this.pageContext.theme}
-                sheetsManager={this.pageContext.sheetsManager}
-              >
-                {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
-                <CssBaseline />
-                <Head>
-                  <title>
-                    Jewellery artist Dovile Kondrasovaite | Dovile Jewellery
-                  </title>
-                  <meta
-                    name="Description"
-                    content="Contemporary amber jewellery with a delicate and modern touch by Dovile Kondrasovaite. Shop authentic handmade jewelry made by independent artist."
-                  />
-                </Head>
+            <MuiThemeProvider
+              theme={this.pageContext.theme}
+              sheetsManager={this.pageContext.sheetsManager}
+            >
+              {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
+              <CssBaseline />
+
+              <Provider store={reduxStore}>
                 {/* Pass pageContext to the _document though the renderPage enhancer
                 to render collected styles on server side. */}
                 <Component pageContext={this.pageContext} {...pageProps} />
-              </MuiThemeProvider>
-            </JssProvider>
-          </Provider>
+              </Provider>
+            </MuiThemeProvider>
+          </JssProvider>
         </Container>
       </React.Fragment>
     );

--- a/pages/piece.js
+++ b/pages/piece.js
@@ -22,6 +22,7 @@ import {
   Text
 } from '../styles/Piece';
 import { Mail } from '../styles/Shared';
+import { AnchorLink } from '../styles/Piece';
 import DialogForm from '../components/DialogForm/DialogForm';
 import { pluralise } from '../util/helpers';
 
@@ -39,7 +40,8 @@ const styles = {
   },
   filterLine: {
     color: '#595959',
-    letterSpacing: '1px'
+    letterSpacing: '1px',
+    lineHeight: '44px'
   },
   svg: {
     top: '.3em',
@@ -137,9 +139,21 @@ const Piece = ({
 
   const pathLine = (
     <div>
-      <Typography inline variant="body2" className={classes.filterLine}>
-        {collection}
-      </Typography>
+      <Link href="/shop">
+        <AnchorLink>
+          <Typography inline variant="body2" className={classes.filterLine}>
+            shop
+          </Typography>
+        </AnchorLink>
+      </Link>
+      <ArrowRight fontSize="small" className={classes.svg} />
+      <Link href={`/shop/${collection}`}>
+        <AnchorLink>
+          <Typography inline variant="body2" className={classes.filterLine}>
+            {collection}
+          </Typography>
+        </AnchorLink>
+      </Link>
       <ArrowRight fontSize="small" className={classes.svg} />
       <Typography inline variant="body2" className={classes.filterLine}>
         {pluralise(category)}

--- a/styles/Piece.js
+++ b/styles/Piece.js
@@ -49,3 +49,11 @@ export const Text = styled.div`
   margin: 0 auto;
 `;
 Text.displayName = 'Text';
+
+export const AnchorLink = styled.a`
+  cursor: pointer;
+  :hover {
+    text-decoration: underline;
+  }
+`;
+AnchorLink.displayName = 'AnchorLink';

--- a/styles/Shared.js
+++ b/styles/Shared.js
@@ -13,6 +13,7 @@ Mail.displayName = 'Mail';
 
 export const AnchorLink = styled.a`
   color: rgba(0, 0, 0, 0.87);
+  cursor: pointer;
 `;
 AnchorLink.displayName = 'AnchorLink';
 


### PR DESCRIPTION
This styles jumping was nagging for quite some time, now looks like this fixed it and there will be no more of styles jumping on first load. Material-ui `<BaselineCss />` before was added somehow late causing a flick of browser margins before resetting to material-ui's baseline defaults.
Also made brand logo as a link to _home_ and added links to my called `pathLine` words.